### PR TITLE
Fix: Mobile navbar issue and underlying structure cleanup

### DIFF
--- a/TripCoordination.UI/Controllers/HomeController.cs
+++ b/TripCoordination.UI/Controllers/HomeController.cs
@@ -34,6 +34,7 @@ namespace TripCoordination.UI.Controllers
 
         public async Task<IActionResult> Index()
         {
+            ViewData["HideSidebarToggle"] = true;
             var towns = await _townRepository.GetAllAsync();
 
             ViewBag.Destination = towns;

--- a/TripCoordination.UI/Views/Shared/_Layout.cshtml
+++ b/TripCoordination.UI/Views/Shared/_Layout.cshtml
@@ -29,10 +29,7 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item">
-                        <a class="nav-link" href="/">Home</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" asp-controller="Trip" asp-action="TripListing">Trips</a>
+                        <a class="nav-link" asp-controller="Trip" asp-action="AllTrips">Trips</a>
                     </li>
                     
                 </ul>

--- a/TripCoordination.UI/Views/Shared/_Layout.cshtml
+++ b/TripCoordination.UI/Views/Shared/_Layout.cshtml
@@ -17,11 +17,19 @@
     <!-- Navbar -->
     <nav class="navbar navbar-expand-md navbar-dark">
         <div class="container">
-            <a asp-action="Index" asp-controller="Home" class="navbar-brand">
-                <span class="fw-bold">
-                    UniTrips
-                </span>
-            </a>
+            <div class="d-flex align-items-center">
+                <!-- Sidebar Toggle -->
+                <button class="btn btn-sm btn-flame d-md-none p-0 me-1 fs-2" type="button" data-bs-toggle="collapse" data-bs-target="#sidebarMenu"
+                    aria-controls="sidebarMenu" aria-expanded="false" aria-label="Toggle sidebar">
+                    <i class="bi bi-list"></i>
+                </button>
+
+                <!-- Brand -->
+                <a asp-action="Index" asp-controller="Home" class="navbar-brand m-0">
+                    <span class="fw-bold">UniTrips</span>
+                </a>
+            </div>
+           
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
                     aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>

--- a/TripCoordination.UI/Views/Shared/_Layout.cshtml
+++ b/TripCoordination.UI/Views/Shared/_Layout.cshtml
@@ -16,7 +16,7 @@
 <body class="d-flex flex-column min-vh-100 body">
     <!-- Navbar -->
     <nav class="navbar navbar-expand-md navbar-dark">
-        <div class="container">
+        <div class="container-fluid">
             <div class="d-flex align-items-center">
                 @if (SignInManager.IsSignedIn(User) && (ViewData["HideSidebarToggle"] as bool? != true))
                 {

--- a/TripCoordination.UI/Views/Shared/_Layout.cshtml
+++ b/TripCoordination.UI/Views/Shared/_Layout.cshtml
@@ -18,12 +18,14 @@
     <nav class="navbar navbar-expand-md navbar-dark">
         <div class="container">
             <div class="d-flex align-items-center">
-                <!-- Sidebar Toggle -->
-                <button class="btn btn-sm btn-flame d-md-none p-0 me-1 fs-2" type="button" data-bs-toggle="collapse" data-bs-target="#sidebarMenu"
-                    aria-controls="sidebarMenu" aria-expanded="false" aria-label="Toggle sidebar">
-                    <i class="bi bi-list"></i>
-                </button>
-
+                @if (SignInManager.IsSignedIn(User) && (ViewData["HideSidebarToggle"] as bool? != true))
+                {
+                    <!-- Sidebar Toggle -->
+                    <button class="btn btn-sm btn-flame d-md-none p-0 me-1 fs-2" type="button" data-bs-toggle="collapse" data-bs-target="#sidebarMenu"
+                        aria-controls="sidebarMenu" aria-expanded="false" aria-label="Toggle sidebar">
+                        <i class="bi bi-list"></i>
+                    </button>
+                }
                 <!-- Brand -->
                 <a asp-action="Index" asp-controller="Home" class="navbar-brand m-0">
                     <span class="fw-bold">UniTrips</span>

--- a/TripCoordination.UI/Views/Shared/_Layout.cshtml
+++ b/TripCoordination.UI/Views/Shared/_Layout.cshtml
@@ -22,7 +22,7 @@
                     UniTrips
                 </span>
             </a>
-            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#sidebarMenu"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
                     aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/TripCoordination.UI/wwwroot/css/site.css
+++ b/TripCoordination.UI/wwwroot/css/site.css
@@ -95,6 +95,14 @@
         color: var(--flame);
     }
 
+.btn-flame i {
+    --flame: #de541e;
+    --dutch-white: #d6d6b1;
+    color: var(--dutch-white);
+
+}
+
+
 
 /*============================================*/
 /*               Sidebar styles               */


### PR DESCRIPTION
This PR addresses the issue where Login/Register links were not visible in mobile view and some underlying problems.

✅ Used bootstrap data-bs-target to toggle the navbar and display the links
✅ created second toggler icon to toggle sidebar
✅ Improved layout spacing and structure

Closes #1