### PR TITLE
Add comprehensive project technical audit report

### DIFF
--- a/docs/PROJECT_TECHNICAL_AUDIT.md
+++ b/docs/PROJECT_TECHNICAL_AUDIT.md
@@ -1,0 +1,1308 @@
+# Trip Coordination Project Technical Audit
+
+**Repository reviewed:** `/workspace/TripCoordination`  
+**Audit date:** 2026-05-31  
+**Audit basis:** Static repository inspection only. No runtime database schema, deployed environment, cloud resources, issue tracker, or external documentation were available. Where evidence was not present, this report states **"Not found in repository."**
+
+---
+
+## SECTION 1: Executive Summary
+
+### Project purpose
+
+Trip Coordination is an ASP.NET Core MVC web application for coordinating shared trips. The repository README describes the product as a platform where students and general users can find, create, join, and request trips to reduce travel cost and improve traveler coordination.
+
+### Intended users
+
+Evidence in controllers, views, seeded roles, and the README indicates these user groups:
+
+- **Students / Users**: browse trips, join trips, leave trips, manage profiles, view student dashboard, submit trip and route requests.
+- **Trip Organizers**: create trips, manage their created trips, inspect participants, access organizer dashboard metrics.
+- **Administrators**: manage users, roles, towns, residences, routes, trips, route requests, trip requests, and dashboards.
+- **Demo users**: the app seeds demo Admin, Student, and Organizer accounts and exposes a demo-login controller.
+
+### Core business problem being solved
+
+The system aims to reduce friction and cost in shared travel coordination by centralizing route discovery, trip publication, destination selection, seat joining, pickup-point capture, participant management, and demand signaling through trip/route requests.
+
+### Current maturity level
+
+**Assessment: MVP / late prototype.**
+
+The application contains a multi-project ASP.NET Core MVC solution, Identity authentication, role-based authorization in many areas, Dapper repositories, stored-procedure based data access, Razor views, dashboards, and test projects. However, production readiness is constrained by hardcoded secrets, weak deployment/CI evidence, missing database DDL scripts for non-Identity tables and stored procedures, incomplete authorization coverage, demo credentials in startup seeding, limited automated tests, limited observability, and technical debt in controllers/repositories.
+
+### Estimated overall project completion
+
+**Estimated completion: 58%.**
+
+Reasoning:
+
+- Core user journeys exist for registration/login, browsing trips, creating trips, joining/leaving trips, route management, request management, dashboards, and admin user management.
+- Important production requirements are not complete: secure configuration, CI/CD, deployment manifests, full tests, operational logging/monitoring, security headers, robust data integrity documentation, database scripts, and API/mobile extensibility.
+
+### High-level strengths
+
+- Clear business concept and visible user-role model.
+- ASP.NET Core MVC + Razor implementation with a layered solution layout.
+- ASP.NET Core Identity with roles is configured.
+- Dapper data access centralizes stored procedure calls through `ISqlDataAccess`/`SqlDataAccess`.
+- Many repository interfaces and implementations exist, supporting testability and dependency injection.
+- Domain and ViewModel classes cover trips, routes, requests, dashboards, profiles, towns, residences, participants, and user roles.
+- Tests project exists with xUnit, Moq, and FluentAssertions dependencies.
+
+### High-level risks
+
+- **Critical security risk:** hardcoded SQL credentials and commented production credentials exist in `appsettings.json`.
+- **Critical security risk:** demo/admin accounts are seeded with known passwords at startup.
+- **Database portability risk:** stored procedures are heavily depended on, but SQL definitions for application tables/procedures were not found in repository.
+- **Authorization risk:** some admin management actions lack `[Authorize(Roles = "Admin")]` even though they are administrative.
+- **Reliability risk:** repositories catch exceptions and return false/empty collections while writing to console, which can hide failures.
+- **Maintainability risk:** controllers contain commented-out code, duplicated flows, inconsistent naming, and large action methods.
+
+### Immediate priorities
+
+1. Remove secrets from committed configuration, rotate exposed credentials, and use user-secrets/key vault/environment variables.
+2. Disable or environment-gate demo login and seeded demo/admin passwords.
+3. Add missing `[Authorize]`/role attributes and anti-forgery attributes to all state-changing MVC actions.
+4. Add database schema and stored procedure scripts or EF migrations for all non-Identity objects.
+5. Add CI that restores, builds, tests, and scans for secrets.
+6. Improve error logging using `ILogger<T>` and stop swallowing repository exceptions silently.
+
+---
+
+## SECTION 2: Repository Overview
+
+### Solution structure
+
+Discovered solution/projects:
+
+| Project | Type | Purpose | Key dependencies | Responsibilities |
+|---|---:|---|---|---|
+| `TripCoordination.UI` | ASP.NET Core MVC web app | User-facing application, Razor views, controllers, Identity pages, startup configuration | `TripCoordination.Data`, `TripCoordination.Common`, ASP.NET Core Identity, EF Core SQL Server/SQLite, SQL Client | MVC controllers, views, authentication UI, DI setup, request routing, demo login, static assets |
+| `TripCoordination.Data` | .NET class library | Data access and domain persistence layer | `TripCoordination.Common`, Dapper, SQL Client, EF Core SQL Server, Identity EF Core | Repositories, repository interfaces, Dapper stored procedure calls, Identity DbContext, domain models, town-sync service |
+| `TripCoordination.Common` | .NET class library | Shared view models and validation attribute | ASP.NET MVC/Core MVC package references | Cross-layer DTO/ViewModel types and `MinSelectedItemsAttribute` |
+| `TripCoordination.Tests` | .NET test project | Automated unit tests | xUnit, Moq, FluentAssertions, UI/Data/Common projects | Controller tests for student and trip creator flows |
+| `ClassLibrary1` | .NET class library | Placeholder/unused library | Not found beyond default project | Contains only `Class1.cs`; no integration found |
+
+### Notable folders
+
+- `TripCoordination.UI/Controllers`: MVC controllers.
+- `TripCoordination.UI/Views`: Razor MVC views.
+- `TripCoordination.UI/Areas/Identity/Pages`: custom Identity Register/Login Razor Pages.
+- `TripCoordination.UI/ViewModel`: UI-specific ViewModel subclasses.
+- `TripCoordination.Data/Repository`: repository interfaces and Dapper implementations.
+- `TripCoordination.Data/DataAccess`: shared Dapper wrapper.
+- `TripCoordination.Data/Models/Domain`: domain model classes.
+- `TripCoordination.Data/Migrations`: EF migrations for ASP.NET Identity tables and `ApplicationUser.CreatedAt`.
+- `TripCoordination.Common/ViewModel`: shared ViewModels.
+
+### Dependency flow diagram
+
+```text
+Browser / Users
+    ↓
+TripCoordination.UI
+    ├─ Controllers + Razor Views
+    ├─ ASP.NET Core Identity Pages
+    └─ UI-specific ViewModels
+    ↓
+TripCoordination.Common
+    └─ shared ViewModels / validation
+    ↓
+TripCoordination.Data
+    ├─ repository interfaces + implementations
+    ├─ services such as TownSyncService
+    ├─ domain models
+    └─ SqlDataAccess / Dapper
+    ↓
+SQL Server stored procedures + ASP.NET Identity tables
+    ↓
+Database
+
+External API:
+TripCoordination.Data.TownSyncService → Back4App Parse API for South African cities
+```
+
+### Dependency observations
+
+- The intended layered pattern is UI → Common/Data → SQL Server.
+- `TripCoordination.Data` references `TripCoordination.Common`, and in at least one repository imports `TripCoordination.ViewModel`, coupling the data layer to UI-specific models.
+- `TripCoordination.Common` references MVC packages, which makes it less framework-neutral than a pure DTO library.
+- `ClassLibrary1` appears unused. No project reference from the main application was found.
+
+---
+
+## SECTION 3: Feature Inventory
+
+### Feature status table
+
+| Category | Feature | Status | Notes |
+|---|---|---:|---|
+| Authentication | User registration | Partial | Identity Register page exists and allows role selection; email confirmation is disabled. |
+| Authentication | User login | Partial | Identity Login page exists; redirects by role. Login uses `lockoutOnFailure: false`. |
+| Authentication | Demo login | Complete for demo / risky for production | `DemoLoginController` signs into seeded demo accounts with known passwords. |
+| Authentication | Logout | Not found in repository | Default Identity UI may provide if scaffolded elsewhere, but explicit logout page/action was not found. |
+| Authorization | Role-based authorization | Partial | Admin/Organizer/Student role attributes exist in several controllers/actions. Coverage is inconsistent. |
+| Authorization | Policy-based authorization | Missing | Not found in repository. |
+| Trip Management | Browse/search trip listing | Complete | Trip listing accepts destination/departure/pickup data and uses `sp_Find_Trips`. |
+| Trip Management | Trip details | Complete | Trip details combines trip data, destinations, and towns. |
+| Trip Management | Trip creation | Complete / needs hardening | Admin/Organizer create flow exists; persists trip and selected stops/destinations. |
+| Trip Management | Trip deletion | Partial | Soft delete exists; authorization and anti-forgery should be verified for all deletion endpoints. |
+| Trip Management | Join trip | Complete / needs validation review | Joins trip through `sp_Join_Trip`; seat validation appears delegated to stored procedure. |
+| Trip Management | Leave trip | Complete | `TripParticipantRepository` exposes leave/remove procedures and user my-trips flow exists. |
+| Trip Management | Organizer My Trips | Complete | `TripCreatorController` uses repository calls for organizer trips. |
+| Trip Management | Participant management | Partial | Participants can be viewed/deleted by trip; authorization constraints should be tightened. |
+| Route Management | View routes | Complete | `RouteController.ViewRoutes`. |
+| Route Management | Route details | Complete | `RouteController.RouteDetails`. |
+| Route Management | Create route | Complete | Admin/Organizer role required. |
+| Route Management | Edit route | Complete | Admin/Organizer role required. |
+| Route Management | Delete route | Complete | Admin-only soft delete. |
+| Requests | Trip requests | Complete / partial workflow | Create, view, delete, approve procedures exist; approval outcome details not visible without DB script. |
+| Requests | Route requests | Complete / partial workflow | Create, user list, admin list, delete, approve actions exist. |
+| Dashboards | Admin dashboard | Partial | User/trip stats, recent activity, role distribution, trips-by-month endpoints exist. |
+| Dashboards | Student dashboard | Partial | Upcoming trip, recent requests, stats, chart endpoints exist. |
+| Dashboards | Organizer dashboard | Partial | Organizer stats, upcoming trip, recent requests, monthly count, seat utilization exist. |
+| Administration | User listing | Complete | Admin can list users through repository. |
+| Administration | Block/unblock users | Complete | Uses Identity lockout APIs. |
+| Administration | Edit user role | Complete / risky | Uses Identity roles, but role field naming suggests UI mismatch risk. |
+| Administration | Manage towns | Complete | CRUD through stored procedures. |
+| Administration | Manage residences | Complete | CRUD through stored procedures. |
+| Administration | Manage trips | Partial | Listing and detail management exist; full moderation workflow not evident. |
+| Reporting | Reports/exporting | Missing | Not found in repository. |
+| Notifications | Email/SMS/in-app notifications | Missing | `IEmailSender` is injected by Identity Register page, but no concrete sender or notification workflow found. |
+| User Management | Profile create/edit/view | Complete / partial | Profile flows exist; authorization is not class-level, and validation is split between domain and ViewModel. |
+| User Management | Password reset/account confirmation | Missing/partial | Default Identity references may exist, but scaffolded reset/confirmation pages were not found. |
+| Integrations | Town sync from Back4App | Partial | Service syncs city names from Back4App; keys in appsettings are placeholders. |
+
+### Completed features
+
+- ASP.NET Identity-based account creation and login.
+- Seeded roles and demo accounts.
+- Role-based dashboards for Admin, Student, and Organizer.
+- Trip listing, trip details, trip creation, join trip, leave/remove participant.
+- Route CRUD.
+- Trip request CRUD/approval.
+- Route request CRUD/approval.
+- Town and residence CRUD.
+- User blocking/unblocking and role editing.
+- Profile view/complete/edit.
+
+### Partial features
+
+- Authorization coverage: present but inconsistent.
+- Dashboards: present but tied to stored procedures not available for audit.
+- Notifications: Identity email sender is referenced, but no implementation found.
+- Database design: domain classes and migrations exist, but complete schema/procedure definitions not found.
+- Testing: project and some controller tests exist, but coverage is narrow.
+
+### Missing features
+
+- CI/CD pipeline.
+- Infrastructure/deployment manifests.
+- Environment-specific secure secret management beyond `UserSecretsId`.
+- Health checks and monitoring.
+- Audit/security logging.
+- Reporting/exporting.
+- REST API for external/mobile clients.
+- Policy-based authorization.
+- Full account management pages such as password reset/email confirmation. Not found in repository.
+
+---
+
+## SECTION 4: Architecture Review
+
+### Architectural pattern
+
+The project is primarily a **layered ASP.NET Core MVC architecture**:
+
+- Presentation layer: `TripCoordination.UI` controllers, Razor views, Identity pages, static assets.
+- Shared model layer: `TripCoordination.Common` ViewModels.
+- Data/domain layer: `TripCoordination.Data` repositories, services, Dapper data access, domain models, DbContext.
+- Database layer: SQL Server stored procedures and Identity tables.
+
+The data access pattern is **Repository + Dapper + stored procedures** with EF Core used mainly for ASP.NET Identity migrations/context.
+
+### Layering approach
+
+Positive layering evidence:
+
+- Controllers receive repository interfaces via DI.
+- Repositories isolate stored procedure names and Dapper calls from most controllers.
+- Shared ViewModels avoid placing all UI shapes directly in controllers.
+- `SqlDataAccess` centralizes connection creation and `CommandType.StoredProcedure` use.
+
+Layering concerns:
+
+- The data layer imports UI namespace `TripCoordination.ViewModel` in `TripRepository`, which breaks clean dependency direction.
+- `TripCoordination.Common` depends on MVC packages, limiting reuse outside MVC.
+- The repository layer mixes domain models and view models as persistence inputs/outputs.
+- Business rules appear split between controllers, repositories, and stored procedures. Because stored procedure definitions are absent, full rule location cannot be audited.
+
+### Separation of concerns
+
+- **Controllers:** Mostly orchestration, but some are large and contain view population, role/profile checks, TempData decisions, and flow logic. `TripController` is especially large and includes commented alternate implementation.
+- **Repositories:** Handle persistence, but frequently catch exceptions and return boolean/empty data, which mixes error policy with data access.
+- **ViewModels:** Rich set of request/view shapes exists. Some UI-specific ViewModels inherit Common ViewModels, which is acceptable but increases hierarchy complexity.
+- **Stored procedures:** Central to behavior. Definitions were not found, so the application has a hidden business/data layer outside the repository.
+- **Services:** `TownSyncService` is a real service abstraction for external API sync. Profile service exists but appears thin.
+
+### Coupling level
+
+**Moderate to high.**
+
+- Controllers depend on multiple repositories and Identity managers.
+- Repositories depend on exact stored procedure names and result shapes.
+- Data layer depends on UI-specific view models in places.
+- Absence of procedure scripts increases coupling to a specific manually maintained database instance.
+
+### Maintainability
+
+**Moderate.** The project is understandable, but maintainability is reduced by inconsistent naming, absent database scripts, swallowed exceptions, duplicated/commented code, and lack of comprehensive tests.
+
+### Review by component
+
+#### Controllers
+
+- 13 controllers found.
+- Controllers use constructor injection and async actions widely.
+- Multiple controllers have role attributes where expected, but some admin management actions in `AdminController` do not consistently show admin authorization.
+- Several POST actions lack `[ValidateAntiForgeryToken]`.
+- Exception handling often sets TempData but does not log details.
+
+#### Repositories
+
+- 16 repository interfaces/implementations or dashboard repositories found.
+- Most repositories call named stored procedures through `ISqlDataAccess`.
+- Dapper parameter objects are used, which is positive for SQL injection protection.
+- Many catch blocks return `false`, `null`, or empty collections, reducing observability.
+
+#### ViewModels
+
+- 27 Common ViewModel files and 5 UI ViewModel files found.
+- Data annotations exist on several forms such as routes, profiles, trip listing, trip requests, and route requests.
+- Some naming is inconsistent (`TripListingViewModelUI`, `CreateTripViewModelUI`, Common `CreateTripViewModel`).
+
+#### Stored procedures
+
+- 67 stored procedure names are referenced by repositories.
+- Actual `.sql` scripts or stored procedure definitions were not found in repository.
+- This is the largest architecture portability and auditability gap.
+
+#### Entities
+
+- Domain models cover users, profiles, roles, residences, towns, trips, trip destinations, participants, trip/route requests, and routes.
+- EF relationships for non-Identity entities are not configured in `ApplicationDbContext`; stored procedures appear to own most relational behavior.
+
+#### Services
+
+- `TownSyncService` integrates Back4App city data.
+- `ProfileService` exists but requires further review before assuming rich domain behavior.
+
+### Architecture score
+
+**6 / 10**
+
+### Good practices
+
+- Multi-project solution separates UI, Data, Common, and Tests.
+- Dependency injection for repositories and services.
+- Repository interfaces enable mocking.
+- Identity roles are integrated.
+- Dapper uses stored procedure command type and parameter objects.
+- Dashboards are separated into dashboard repositories.
+
+### Architectural risks
+
+- Database behavior is opaque because stored procedures are not versioned in the repository.
+- Data layer depends on UI namespace/model types.
+- No application service layer for use cases; controllers coordinate many business flows directly.
+- Inconsistent authorization creates possible privilege escalation risk.
+- Errors are swallowed in repositories, making production diagnosis difficult.
+- `ClassLibrary1` suggests scaffold/unused artifact.
+
+### Refactoring recommendations
+
+1. Add an application/use-case service layer for trip creation, joining, leaving, request approval, and admin workflows.
+2. Move all UI-specific view models out of Data dependencies; Data should return domain/DTOs independent of UI.
+3. Version database schema and stored procedure scripts under a `database/` or migration project.
+4. Replace broad repository catch/return-false patterns with structured logging and typed result/error handling.
+5. Apply class-level authorization on admin/organizer/student controllers and explicit allow-anonymous only where needed.
+6. Remove unused `ClassLibrary1` if truly unused.
+
+---
+
+## SECTION 5: Database Assessment
+
+### Located database artifacts
+
+| Artifact type | Findings |
+|---|---|
+| SQL scripts | Not found in repository. |
+| Stored procedure definitions | Not found in repository. Procedure names are referenced in C# repositories only. |
+| EF migrations | Found for ASP.NET Identity tables and `ApplicationUser.CreatedAt`. |
+| DbContext | `TripCoordination.Data/Models/Data/ApplicationDbContext.cs` extends `IdentityDbContext<ApplicationUser>`. |
+| Duplicate/legacy DbContext | `TripCoordination.UI/Areas/Identity/Data/ApplicationDbContext.cs` contains a fully commented-out context. |
+| Domain database models | Found in `TripCoordination.Data/Models/Domain`. |
+
+### Tables discovered or inferred
+
+Because non-Identity DDL was not found, the following table list is inferred from domain models and stored procedure names. Exact SQL definitions, constraints, and indexes are **Not found in repository.**
+
+| Table/model | Purpose | Relationships inferred |
+|---|---|---|
+| `AspNetUsers` / `ApplicationUser` | Identity users with added `CreatedAt` property | Identity roles, claims, logins, tokens. |
+| `AspNetRoles` | Identity roles | Linked to users through `AspNetUserRoles`. |
+| `AspNetUserRoles` | Identity user-role mapping | Users ↔ roles. |
+| `AspNetUserClaims` | Identity claims | User → claims. |
+| `AspNetRoleClaims` | Identity role claims | Role → claims. |
+| `AspNetUserLogins` | External logins | User → external login providers. |
+| `AspNetUserTokens` | Identity tokens | User → tokens. |
+| `Profiles` / `Profile` | Extended user profile data: title, name, surname, email, phone, address, DOB, residence | `UserID` → Identity user; `ResidenceID` → Residence. FK constraints not found. |
+| `Residences` / `Residence` | Residence names and addresses | Referenced by Profile. |
+| `Roles` / `Role` | Custom role entity with `RoleID`/`RoleName` | Duplicates/conflicts conceptually with Identity roles. |
+| `UserRoles` / `UserRole` | Custom user-role entity | `UserID` + `RoleID`; also duplicates Identity user-role mapping. |
+| `Towns` / `Town` | Town/city destinations with region, country, price, created timestamp | Referenced by trip destination and listing/search. |
+| `Trips` / `Trip` | Trip header with route/town/user/date/seat/full state | Creator user; route/town; destinations; participants. Domain model has `TownID`, repository create uses `RouteID`. |
+| `TripDestinationTowns` / `TripDestinationTown` | Junction between trip and destination town | `TripID` → Trip; `TownID` → Town. |
+| `TripParticipants` / `TripParticipant` | Joined users, destination, seat, pickup point | `TripID` → Trip; `UserID` → user; `DestinationTownID` → TripDestinationTown/Town. |
+| `TripRequests` / `TripRequest` | User demand request for a trip from/to/date | `UserID` → user. |
+| `RouteRequests` / `RouteRequest` | User demand request for route addition | `UserID` → user. |
+| `Routes` / `TripRoute` | Route definitions with description/from/to and soft-delete flag | Referenced by Trip create flow. |
+
+### Stored procedure inventory and call chain
+
+Repository-to-procedure mapping is based on string references in repository code. Controller-to-repository mapping is based on constructor dependencies and action names.
+
+| Stored procedure | Purpose inferred | Repository | Controllers using related repository |
+|---|---|---|---|
+| `sp_Admin_GetRecentActivity` | Admin recent activity feed | `AdminDashboardRepository` | `AdminController` |
+| `sp_Admin_GetTripOverview` | Admin trip summary stats | `AdminDashboardRepository` | `AdminController` |
+| `sp_Admin_GetTripsCreatedByMonth` | Monthly trips chart | `AdminDashboardRepository` | `AdminController` |
+| `sp_Admin_GetUserSummary` | Admin user stats | `AdminDashboardRepository` | `AdminController` |
+| `sp_GetUserRoleDistribution` | User-role distribution chart | `AdminDashboardRepository` | `AdminController` |
+| `sp_GetOganizerStats` | Organizer dashboard stats | `OrganizerDashboardRepository` | `TripCreatorController` |
+| `sp_GetOrganizerUpcomingTrip` | Organizer next/upcoming trip | `OrganizerDashboardRepository` | `TripCreatorController` |
+| `sp_GetRecentTripRequests` | Organizer recent trip requests | `OrganizerDashboardRepository` | `TripCreatorController` |
+| `sp_Organizer_GetMonthlyTripCount` | Organizer monthly trip chart | `OrganizerDashboardRepository` | `TripCreatorController` |
+| `sp_Organizer_GetSeatUtilizationByTrip` | Seat utilization chart | `OrganizerDashboardRepository` | `TripCreatorController` |
+| `sp_GetNextUpcomingTrip` | Student next trip | `StudentDashboardRepository` | `StudentController` |
+| `sp_GetStudentTripStats` | Student trip stats | `StudentDashboardRepository` | `StudentController` |
+| `sp_GetUsersRecentTripRequests` | Student recent requests | `StudentDashboardRepository` | `StudentController` |
+| `sp_Student_GetTripRequestatusDestripution` | Student trip request status chart; name appears misspelled | `StudentDashboardRepository` | `StudentController` |
+| `sp_Student_GetTripsJoinedByMonth` | Student monthly joined trips | `StudentDashboardRepository` | `StudentController` |
+| `sp_Create_Profile` | Create profile | `ProfileRepository` | `ProfileController` |
+| `sp_Delete_Profile` | Delete profile | `ProfileRepository` | `ProfileController` |
+| `sp_Get_Profile` | Get profile by ID | `ProfileRepository` | `ProfileController` |
+| `sp_Get_Profiles` | List profiles | `ProfileRepository` | `ProfileController` |
+| `sp_Get_User_Profile` | Get profile for user | `ProfileRepository` | `ProfileController` |
+| `sp_Update_Profile` | Update profile | `ProfileRepository` | `ProfileController` |
+| `sp_Create_Residence` | Create residence | `ResidenceRepository` | `AdminController`, `ProfileController` |
+| `sp_Delete_Residence` | Delete residence | `ResidenceRepository` | `AdminController`, `ProfileController` |
+| `sp_Get_Residence` | Get residence | `ResidenceRepository` | `AdminController`, `ProfileController` |
+| `sp_Get_Residences` | List residences | `ResidenceRepository` | `AdminController`, `ProfileController` |
+| `sp_Update_Residence` | Update residence | `ResidenceRepository` | `AdminController`, `ProfileController` |
+| `sp_Create_Role` | Create custom role | `RoleRepository` | No direct controller found; Identity roles used in `UserController`. |
+| `sp_Delete_Role` | Delete custom role | `RoleRepository` | No direct controller found. |
+| `sp_Get_Role` | Get custom role | `RoleRepository` | No direct controller found. |
+| `sp_Get_Roles` | List custom roles | `RoleRepository` | No direct controller found. |
+| `sp_Update_Role` | Update custom role | `RoleRepository` | No direct controller found. |
+| `sp_Create_Route` | Create route | `RouteRepository` | `RouteController` |
+| `sp_Delete_Route` | Soft delete route | `RouteRepository` | `RouteController` |
+| `sp_Get_All_Routes` | List routes | `RouteRepository` | `RouteController`, `TripController` |
+| `sp_Get_Route_ByID` | Get route | `RouteRepository` | `RouteController` |
+| `sp_Update_Route` | Update route | `RouteRepository` | `RouteController` |
+| `sp_Add_RouteRequest` | Create route request | `RouteRequestRepository` | `RouteRequestController` |
+| `sp_Approve_RouteRequest` | Approve route request | `RouteRequestRepository` | `RouteRequestController` |
+| `sp_Delete_RouteRequest` | Delete route request | `RouteRequestRepository` | `RouteRequestController` |
+| `sp_Get_All_RouteRequests` | Admin route request list | `RouteRequestRepository` | `RouteRequestController` |
+| `sp_Get_All_User_RouteRequest` | User route request list | `RouteRequestRepository` | `RouteRequestController` |
+| `sp_Get_RouteRequest_By_Id` | Get route request | `RouteRequestRepository` | `RouteRequestController` |
+| `sp_Create_Town` | Create town | `TownRepository` | `AdminController`, `TripController`, `HomeController`, `TownSyncService` |
+| `sp_Delete_Town` | Delete town | `TownRepository` | `AdminController` |
+| `sp_Get_Town` | Get town | `TownRepository` | `AdminController`, `TripController` |
+| `sp_Get_Towns` | List towns | `TownRepository` | `AdminController`, `TripController`, `HomeController`, `TownSyncService` |
+| `sp_Update_Town` | Update town | `TownRepository` | `AdminController` |
+| `sp_Create_TripDestinationTown` | Add trip destination | `TripDestinationTownRepository` | `TripController` |
+| `sp_Get_TripDestinationTown` | Get trip destination | `TripDestinationTownRepository` | `TripController` |
+| `sp_Get_TripDestinationTwons` | List trip destinations; name appears misspelled | `TripDestinationTownRepository` | `TripController` |
+| `sp_Remove_TripDestination` | Remove trip destination | `TripDestinationTownRepository` | `TripController` |
+| `sp_Update_TripDestinationTown` | Update trip destination | `TripDestinationTownRepository` | `TripController` |
+| `sp_Create_TripParticipant` | Add participant | `TripParticipantRepository` | `TripParticipantController`, `TripController` |
+| `sp_Delete_TripParticipant` | Delete participant | `TripParticipantRepository` | `TripParticipantController` |
+| `sp_Get_TripParticipant` | Get participant | `TripParticipantRepository` | `TripParticipantController` |
+| `sp_Get_TripParticipantS` | List participants; inconsistent casing/name | `TripParticipantRepository` | `TripParticipantController` |
+| `sp_Get_TripParticipants_By_TripID` | List trip participants | `TripParticipantRepository` | `TripParticipantController` |
+| `sp_Leave_Trip` | User leaves trip | `TripParticipantRepository` | `TripController` / student trip flow inferred |
+| `sp_Remove_TripParticipant` | Remove participant | `TripParticipantRepository` | `TripParticipantController` |
+| `sp_Update_TripParticipant` | Update participant | `TripParticipantRepository` | `TripParticipantController` |
+| `sp_AddTripStop` | Add trip stop/destination pricing | `TripRepository` | `TripController` |
+| `sp_Create_Trip` | Create trip | `TripRepository` | `TripController` |
+| `sp_Delete_Trip` | Delete trip | `TripRepository` | `TripController`, `AdminController` |
+| `sp_Find_TripDetails` | Find detailed trip | `TripRepository` | `TripController` |
+| `sp_Find_Trips` | Search/list trips | `TripRepository` | `TripController`, `HomeController` |
+| `sp_Find_Trips_With_Destinations` | Search trips with destinations | `TripRepository` | `TripController` |
+| `sp_GetAll_Trips` | List all trips | `TripRepository` | `TripController`, `AdminController`, `TripCreatorController` |
+| `sp_Get_All_User_Trips` | Trips by organizer/user | `TripRepository` | `TripCreatorController` |
+| `sp_Get_Trip` | Get trip | `TripRepository` | `TripController` |
+| `sp_Join_Trip` | Join trip | `TripRepository` | `TripController` |
+| `sp_SoftDelete_Trip` | Soft delete trip | `TripRepository` | `TripController`, `AdminController` |
+| `sp_Update_Trip` | Update trip | `TripRepository` | `TripController` |
+| `sp_Add_TripRequest` | Add trip request | `TripRequestRepository` | `TripRequestController` |
+| `sp_Approve_TripRequest` | Approve trip request | `TripRequestRepository` | `TripRequestController` |
+| `sp_Delete_TripRequest` | Delete trip request | `TripRequestRepository` | `TripRequestController` |
+| `sp_Get_All_TripRequests` | Admin trip request list | `TripRequestRepository` | `TripRequestController` |
+| `sp_Get_All_User_TripRequests` | User trip requests | `TripRequestRepository` | `TripRequestController` |
+| `sp_Get_TripRequest_ByID` | Get trip request | `TripRequestRepository` | `TripRequestController` |
+| `sp_Create_User` | Create custom user | `UserRepository` | `HomeController` legacy/signup; `UserController` uses list/view |
+| `sp_Delete_User` | Delete custom user | `UserRepository` | `UserController` inferred/no delete action found |
+| `sp_Get_JoinedTrips_By_User` | User joined trips | `UserRepository` | `StudentController` |
+| `sp_Get_User` | Get custom user | `UserRepository` | `UserController` |
+| `sp_Get_User_with_Role` | Get user with role | `UserRepository` | `UserController` |
+| `sp_Get_Users` | List users | `UserRepository` | `UserController` |
+| `sp_Update_User` | Update custom user | `UserRepository` | `UserController` inferred/no update action found |
+| `sp_Create_UserRole` | Create custom role mapping | `UserRoleRepository` | No direct controller found. |
+| `sp_Delete_UserRole` | Delete custom role mapping | `UserRoleRepository` | No direct controller found. |
+| `sp_Get_UserRole` | Get custom role mapping | `UserRoleRepository` | No direct controller found. |
+| `sp_Get_UserRoles` | List custom role mappings | `UserRoleRepository` | No direct controller found. |
+| `sp_Update_UserRole` | Update custom role mapping | `UserRoleRepository` | No direct controller found. |
+
+### Missing CRUD operations
+
+- Stored procedure names suggest CRUD exists for towns, residences, roles, user roles, profiles, routes, participants, and trips.
+- Controller workflows for custom `RoleRepository` and `UserRoleRepository` are not evident; Identity roles are used instead.
+- No SQL scripts were found, so actual CRUD completeness cannot be validated.
+- Profile delete exists in repository but no obvious user-facing delete profile action was found.
+- Trip update exists in repository but a full trip edit UI/action was not clearly identified.
+
+### Possible normalization issues
+
+- Identity roles (`AspNetRoles`) coexist with custom `Role` and `UserRole` models/repositories. This is likely redundant and may cause role-source inconsistency.
+- `Trip` domain model includes `TownID`, while trip creation uses `RouteID`; this suggests schema/model drift.
+- `TripParticipant` references `DestinationTownID` and has `PickUpPoint`; the exact relationship to `TripDestinationTown` is unclear without DB constraints.
+- `Town.Price` stores price directly on town, but trip pricing may vary by route/date/organizer; this can become a normalization/business-rule problem.
+
+### Referential integrity concerns
+
+- FK constraints for non-Identity tables are Not found in repository.
+- Deletion procedures and soft delete flags exist, but cascading behavior is Not found in repository.
+- Seat uniqueness, seat limits, and duplicate join prevention appear to depend on `sp_Join_Trip`, whose definition is Not found in repository.
+- `UserID` fields are strings but FK constraints to `AspNetUsers` are Not found in repository.
+
+### Database design score
+
+**5 / 10**
+
+The inferred schema covers core concepts, but lack of committed DDL/procedure scripts, duplicate role systems, model/procedure drift, and unknown constraints significantly reduce confidence.
+
+---
+
+## SECTION 6: Code Quality Review
+
+### Naming consistency
+
+- Generally readable names exist for controllers/repositories/models.
+- Inconsistencies and typos include `DBseeder`, `TripDestinationTwons`, `sp_GetOganizerStats`, `sp_Student_GetTripRequestatusDestripution`, TempData key `Succes`, and class/project `ClassLibrary1`.
+- Role naming mixes `User`, `Student`, `Organizer`, and custom `RoleID`/Identity role names.
+
+### Folder organization
+
+Strengths:
+
+- Clear project folders for UI, Data, Common, and Tests.
+- MVC folders follow standard `Controllers`, `Views`, `Models`, `wwwroot`, `Areas/Identity` conventions.
+- Repositories and services are grouped.
+
+Concerns:
+
+- `TripCoordination.UI/ViewModel` and `TripCoordination.Common/ViewModel` split can be confusing.
+- `TripCoordination.UI/Areas/Identity/Data/ApplicationDbContext.cs` is a commented-out duplicate.
+- `ClassLibrary1` is a placeholder project with no apparent value.
+- A file named `clear` exists at repository root.
+
+### Readability
+
+- Most files are straightforward C# and MVC.
+- Commented-out code blocks and placeholder comments reduce readability.
+- Some methods combine view data setup, authorization checks, database calls, TempData messages, and exception handling.
+
+### Reusability
+
+- Repository interfaces improve reusability and testability.
+- ViewModels support form/view reuse.
+- Business logic is not centralized in domain/application services, reducing reuse across potential MVC/API/mobile interfaces.
+
+### Complexity
+
+- Controllers such as `TripController` and `AdminController` are large and carry many responsibilities.
+- Stored procedures hide complexity outside code review.
+- Error-handling and flow control are repeated across controllers.
+
+### Dead code
+
+Evidence suggests:
+
+- `ClassLibrary1/Class1.cs` is unused.
+- Commented duplicate DbContext in UI Identity area.
+- Commented alternate controller actions and commented appsettings blocks.
+- Custom Role/UserRole repositories may be unused now that Identity RoleManager/UserManager are used.
+
+### Duplicate code
+
+- Repeated try/catch/TempData patterns in controllers.
+- Repeated repository catch/Console.WriteLine/return false patterns.
+- Duplicate role concepts between Identity and custom role models.
+
+### Large methods/controllers
+
+- `TripController` contains many actions and helper methods plus commented code.
+- `AdminController` combines dashboard, residence management, town management, trip management, and sync.
+- Identity Register/Login files include scaffolded code plus custom role logic.
+
+### Missing abstractions
+
+- Application services/use cases for trip creation/joining, requests, administration.
+- Centralized authorization policies.
+- Centralized result/error handling.
+- Structured logging abstraction use in repositories/controllers.
+- Database migration/versioning abstraction for stored procedures.
+
+### Top 10 technical debt items
+
+| Rank | Severity | Technical debt item | Impact |
+|---:|---|---|---|
+| 1 | Critical | Hardcoded database credentials and commented production credential string in `appsettings.json` | Credential compromise and unsafe production deployment. |
+| 2 | Critical | Known demo/admin passwords are seeded at startup | Unauthorized access risk if deployed without gating. |
+| 3 | High | Stored procedures and application database DDL are not versioned in repository | New engineers cannot recreate database; high deployment risk. |
+| 4 | High | Inconsistent authorization and missing anti-forgery on several state-changing actions | Privilege escalation and CSRF risk. |
+| 5 | High | Data layer references UI view models/namespaces | Breaks layering and complicates reuse/testing. |
+| 6 | High | Repositories swallow exceptions and log to console | Production failures become invisible or misleading. |
+| 7 | Medium | Duplicate role models/repositories alongside ASP.NET Identity roles | Role drift and confusion. |
+| 8 | Medium | Large controllers with mixed responsibilities | Harder maintenance and testing. |
+| 9 | Medium | Narrow test coverage | Regression risk across important workflows. |
+| 10 | Low | Naming typos, commented code, placeholder project/files | Reduces professionalism and maintainability. |
+
+---
+
+## SECTION 7: Security Assessment
+
+### Authentication
+
+- ASP.NET Core Identity is configured with `ApplicationUser` and `IdentityRole`.
+- Password requirements are configured: digit, lowercase, uppercase, non-alphanumeric, minimum length 6.
+- Email confirmation is disabled (`RequireConfirmedAccount = false`).
+- Login sets `lockoutOnFailure: false`, so failed login attempts do not trigger account lockout in the observed login path.
+- Demo login bypasses user-entered credentials by selecting known demo accounts and signing in with known password `Demo@123`.
+- Startup seeding creates demo accounts and an admin account with known passwords.
+
+### Authorization
+
+- Role-based authorization is used in many actions: Admin dashboard, user management, route creation/editing/deletion, student dashboard chart endpoints, request approvals.
+- Class-level `[Authorize]` exists on some controllers (`TripController`, `RouteController`, `RouteRequestController`, `UserController`).
+- Some administrative actions in `AdminController` are not individually decorated with `[Authorize(Roles = "Admin")]`, and the class itself is not decorated, creating inconsistent access control.
+- Policy-based authorization: **Not found in repository.**
+
+### Input validation
+
+- Data annotations exist on several ViewModels and domain models.
+- Many POST actions check `ModelState.IsValid`.
+- Some domain entities have minimal validation (`Trip` has required fields but no ranges; `Town.Price` no range; `Seats` no range in domain).
+- Validation likely depends partly on stored procedures for business constraints such as seat capacity and duplicate joins; definitions are not available.
+
+### Database security
+
+- Repository calls use Dapper parameter objects and `CommandType.StoredProcedure`, which is positive for SQL injection resistance.
+- Because stored procedure definitions are absent, dynamic SQL inside procedures cannot be ruled out.
+- Connection strings include `TrustServerCertificate=True`, which may weaken TLS validation depending on environment.
+
+### Secrets
+
+Findings:
+
+- `appsettings.json` contains a real-looking `connSomee` SQL Server connection string with `user id` and `pwd`.
+- `appsettings.json` contains a commented SQL connection string with a database username and password.
+- Back4App App ID and REST API key are placeholders (`MY_APP_ID`, `MY_API_KEY`).
+- A `UserSecretsId` exists in the UI `.csproj`, but committed appsettings still contain secrets.
+
+### Security headers
+
+- HTTPS redirection and HSTS are configured for non-development environments.
+- Additional headers such as Content-Security-Policy, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, and frame protections were **Not found in repository.**
+
+### Logging
+
+- Default logging is configured.
+- `ILogger` is used in Identity login/register scaffolding.
+- Controllers/repositories often catch exceptions without logging or write to `Console.WriteLine`.
+- Audit logging and security event logging: **Not found in repository.**
+
+### Critical vulnerabilities
+
+1. Hardcoded database credentials in committed configuration.
+2. Known seeded admin/demo credentials and demo login endpoint.
+3. Inconsistent authorization around admin management actions.
+4. Missing anti-forgery on some POST state-changing actions.
+5. Stored procedure definitions unavailable, preventing verification of SQL injection protections and authorization/data integrity logic.
+
+### Medium risks
+
+- Lockout disabled on login failures.
+- Email confirmation disabled.
+- No MFA/two-factor implementation surfaced beyond default scaffold references.
+- Missing security headers.
+- Broad `AllowedHosts: "*"`.
+- `TrustServerCertificate=True` in connection strings.
+- Exception messages may be exposed to users in some TempData paths.
+
+### Recommended security fixes
+
+1. Rotate all exposed credentials immediately.
+2. Remove credentials from `appsettings.json`; use environment variables, user secrets for local dev, and managed secrets in production.
+3. Gate demo seeding/login to development only, or remove it before production.
+4. Add `[Authorize(Roles = "Admin")]` at `AdminController` class level; use `[AllowAnonymous]` only for public endpoints.
+5. Add `[ValidateAntiForgeryToken]` to all POST actions that mutate state.
+6. Enable account lockout on login failure and consider email confirmation/MFA.
+7. Add security headers middleware.
+8. Add audit logging for login, role change, block/unblock, approve/delete requests, trip creation/deletion, and participant removal.
+9. Commit reviewed SQL scripts and test stored procedures for parameterization/no dynamic SQL injection.
+
+### Security score
+
+**4 / 10**
+
+The use of Identity and parameterized Dapper calls is positive, but committed credentials, seeded known passwords, inconsistent authorization, absent audit logging, and missing security headers are serious blockers.
+
+---
+
+## SECTION 8: DevOps Readiness Assessment
+
+### CI/CD
+
+| CI/CD system | Finding |
+|---|---|
+| GitHub Actions | Not found in repository. |
+| Azure DevOps pipeline | Not found in repository. |
+| Other pipeline config | Not found in repository. |
+
+### Deployment
+
+Hosting assumptions inferred:
+
+- ASP.NET Core web app targeting .NET 8.
+- SQL Server database.
+- Local development uses SQL Server Express/localdb-style connection strings.
+- Somee.com SQL Server connection string is present, suggesting possible shared-hosting or remote SQL hosting intent.
+- No Dockerfile, compose file, IaC, deployment scripts, Azure App Service config, Kubernetes manifests, or publish profile were found.
+
+### Configuration management
+
+- `appsettings.json` and `appsettings.Development.json` exist.
+- `UserSecretsId` exists in UI project.
+- Environment separation is weak: committed appsettings contain local, Somee, and commented production-like connection strings together.
+- Strongly typed options classes were not found.
+- Secret handling is not production-ready.
+
+### Observability
+
+- ASP.NET Core logging is configured with default levels.
+- No structured logging provider such as Serilog, Application Insights, OpenTelemetry, or Seq was found.
+- No health checks were found.
+- No monitoring dashboards or alerts were found.
+- No audit logging was found.
+
+### Backup strategy
+
+**Not found in repository.**
+
+No database backup/restore scripts, scheduled jobs, or runbooks were found.
+
+### DevOps maturity score
+
+**2 / 10**
+
+The repository is runnable as a .NET solution but lacks production DevOps evidence: CI, deployment manifests, secure config, observability, health checks, and backup runbooks.
+
+### Immediate improvements
+
+1. Add GitHub Actions workflow: restore, build, test, secret scan.
+2. Add environment-specific appsettings templates without secrets.
+3. Add Dockerfile or documented Azure App Service deployment path.
+4. Add database migration/procedure deployment scripts.
+5. Add `dotnet format` or style checks in CI.
+6. Add dependency vulnerability scanning.
+
+### Production readiness actions
+
+- Implement secure secrets management.
+- Create deployment runbook and rollback procedure.
+- Add health endpoint and uptime monitoring.
+- Add database backup/restore plan.
+- Add logging/telemetry with correlation IDs.
+- Add staging environment and smoke tests.
+
+---
+
+## SECTION 9: Performance & Scalability
+
+### Query design
+
+- Stored procedures are used for most database operations, which can be efficient when indexed and written well.
+- Stored procedure definitions are absent, so query plans, indexes, joins, and filtering cannot be validated.
+- Search/list endpoints likely return collections without visible pagination.
+
+### Repository patterns
+
+- Dapper is lightweight and efficient for read/write stored procedure calls.
+- `SqlDataAccess` opens a new SQL connection per operation, which relies on ADO.NET connection pooling. This is normal for ASP.NET Core.
+- Some operations perform multiple sequential database calls from controllers, such as populating trip create data and adding destinations/stops after creating a trip.
+- One repository method uses `.Result` on an async call (`CreateTripAsync` returns `int` despite async naming), which can create blocking/deadlock/performance issues.
+
+### Dapper usage
+
+- Positive: Parameterized anonymous objects and stored procedure command type.
+- Concern: Result mapping depends entirely on stored procedure result column names matching ViewModel/domain properties.
+- Concern: Error behavior returns default values, which may hide performance/database faults.
+
+### Pagination
+
+Pagination support is **Not found in repository** for trip listings, user management, requests, towns, residences, or dashboards.
+
+### Caching
+
+Caching is **Not found in repository.** Towns/routes/residences could be cached if they are relatively static.
+
+### Current scalability limits
+
+- Single MVC app with SQL Server backend and server-rendered pages is suitable for small/medium use if database is indexed.
+- Lack of pagination will become a bottleneck as users/trips/requests grow.
+- Hidden stored procedure implementations make indexing and execution-plan quality unknown.
+- No distributed cache, background jobs, message queues, or async workflow infrastructure.
+- No API boundary for mobile/SPA clients.
+- No observability to detect bottlenecks.
+
+### User-scale readiness estimates
+
+| Scale | Readiness | Rationale |
+|---|---|---|
+| 100 users | Likely ready after security fixes | Basic MVC + SQL Server should handle this if DB exists and procedures are functional. |
+| 1,000 users | Conditional | Needs pagination, indexing validation, logging, and connection/config tuning. |
+| 10,000 users | Not ready without work | Requires query/index review, caching for reference data, operational monitoring, production deployment architecture, and load testing. |
+| 100,000 users | Not ready | Requires major architecture evolution: API layer, scalable hosting, background processing, caching, observability, database scaling strategy, robust security/compliance. |
+
+### Bottlenecks
+
+- Unpaginated list endpoints.
+- Unknown stored procedure performance and indexing.
+- Sequential multi-call workflows for trip creation and dashboards.
+- Missing caching for towns/routes/residences.
+- Blocking `.Result` call in trip creation repository method.
+- No production telemetry to identify slow endpoints.
+
+---
+
+## SECTION 10: Recruiter Assessment
+
+### Estimated developer level
+
+**Intermediate.**
+
+The repository demonstrates more than junior-level capability: multi-project .NET solution, ASP.NET Core MVC, Identity roles, Dapper repository pattern, stored procedures, dashboards, ViewModels, dependency injection, and tests. However, production-grade security, DevOps, clean architecture boundaries, database versioning, observability, and polish are not yet senior-level.
+
+### Justification
+
+Evidence of intermediate strengths:
+
+- Can build a full-stack MVC application with authentication and role-based experiences.
+- Understands layered projects, repositories, DI, and stored procedure based persistence.
+- Has implemented multiple user workflows and admin dashboards.
+- Has started automated testing with xUnit/Moq/FluentAssertions.
+
+Evidence of gaps:
+
+- Hardcoded credentials and known seeded passwords.
+- Missing CI/CD and deployment artifacts.
+- Stored procedures not version-controlled.
+- Inconsistent authorization/anti-forgery.
+- Controllers and repositories need cleaner separation and error handling.
+
+### Demonstrated skills
+
+#### Backend
+
+- ASP.NET Core MVC controllers and Razor Pages.
+- ASP.NET Core Identity with roles.
+- Dependency injection.
+- Async controller/repository methods.
+- Dapper data access.
+
+#### Database
+
+- SQL Server connection usage.
+- Stored procedure first data access.
+- EF Core Identity migrations.
+- Domain modeling for trips, profiles, routes, towns, requests, participants.
+
+#### Architecture
+
+- Multi-project layering.
+- Repository interfaces and implementations.
+- Shared ViewModels.
+- Basic services abstraction.
+
+#### Security
+
+- Identity authentication and role authorization.
+- Password complexity configuration.
+- HTTPS/HSTS middleware.
+- Parameterized Dapper calls.
+
+#### DevOps
+
+- Minimal evidence. Can configure local appsettings and .NET project files.
+- CI/CD, IaC, observability, and deployment automation are not demonstrated.
+
+#### Frontend
+
+- Razor views.
+- Bootstrap/static assets.
+- jQuery validation and chart JavaScript assets.
+- Layouts/sidebar/login partials.
+
+#### Documentation
+
+- README exists with purpose, features, tech stack, and layered architecture summary.
+- Detailed setup/run/database docs are not found.
+
+### Employability strengths
+
+- Strong candidate for junior-to-mid .NET MVC/backend roles.
+- Practical experience building CRUD, dashboards, authentication, and SQL-backed workflows.
+- Comfortable with repository pattern and stored procedures.
+- Has enough project breadth to discuss real application tradeoffs.
+
+### Gaps to address
+
+- Security hygiene and secrets management.
+- CI/CD and cloud deployment.
+- Clean architecture/application service layer.
+- Database migration/versioning discipline.
+- Comprehensive testing and code quality automation.
+- Observability and operational readiness.
+
+---
+
+## SECTION 11: Software Architect Assessment
+
+### Extensibility
+
+Current extensibility is moderate for new MVC pages and stored procedure-backed features. Adding another server-rendered CRUD module is straightforward. Extending to APIs, mobile clients, and integrations will be harder because use-case logic is tied to controllers and stored procedures rather than application services.
+
+### Maintainability
+
+Maintainability is fair for a small team but will degrade as feature count grows unless controllers are split, business logic is centralized, and stored procedures are versioned/tested. The repository pattern helps, but hidden database logic and inconsistent error handling are limiting.
+
+### Domain modeling
+
+Domain model coverage is broad but not yet rich. Models are mostly data containers. Business invariants such as seat capacity, duplicate joining, trip lifecycle, approval behavior, and soft-delete rules appear externalized to stored procedures or controllers. A stronger domain/application layer would improve clarity.
+
+### Future scalability
+
+The MVC + SQL Server architecture can scale to early MVP usage. It needs significant operational and architectural upgrades for high growth: pagination, caching, API boundaries, load balancing, database indexing, background jobs, telemetry, and secure configuration.
+
+### Would this architecture support a mobile application?
+
+**Not directly.** A mobile app would require a REST/JSON API or GraphQL layer. Recommended changes:
+
+- Add `TripCoordination.Api` or API controllers in UI.
+- Move business logic from MVC controllers into application services reusable by MVC and API.
+- Add JWT/OIDC flows or Identity endpoints suitable for mobile.
+- Create API-specific DTOs and versioning.
+
+### Would this architecture support a REST API?
+
+**With refactoring.** Repository interfaces can be reused, but MVC controllers currently own workflow logic. Required changes:
+
+- Application services for trip, route, request, dashboard, profile, and admin use cases.
+- API DTOs separated from Razor ViewModels.
+- OpenAPI/Swagger.
+- API auth, rate limiting, validation filters, global exception handling.
+
+### Would this architecture support external integrations?
+
+**Partially.** `TownSyncService` demonstrates one outbound integration. Required changes:
+
+- Typed HTTP clients/options.
+- Retry/circuit-breaker policies.
+- Background job scheduling for syncs.
+- Integration logging and dead-letter/error handling.
+- Secret management for API keys.
+
+### Would this architecture support real-time notifications?
+
+**Not currently.** Required changes:
+
+- SignalR hub or notification service.
+- Notification domain model/table.
+- Background jobs/event dispatching.
+- User notification preferences.
+- Delivery channels: email/SMS/push/in-app.
+
+### Would this architecture support payment integration?
+
+**Not safely without changes.** Required changes:
+
+- Payment domain model and order/transaction lifecycle.
+- PCI-conscious integration with a payment provider.
+- Webhook endpoints with signature validation.
+- Idempotency keys and reconciliation jobs.
+- Secure secrets and audit logging.
+- Clear trip pricing model separate from `Town.Price`.
+
+---
+
+## SECTION 12: Project Roadmap
+
+### Phase 1: Highest-priority missing items
+
+**Goal:** Make the repository safe and reproducible for continued development.  
+**Estimated effort:** 2-3 weeks.
+
+- Remove and rotate hardcoded credentials.
+- Gate/remove demo login and seeded known passwords.
+- Add class/action-level authorization audit and anti-forgery on all mutation endpoints.
+- Commit database DDL/stored procedure scripts or create complete migrations.
+- Add basic GitHub Actions CI: restore, build, test.
+- Add structured logging through `ILogger<T>` in controllers/repositories.
+- Remove unused/commented duplicate artifacts where safe.
+
+### Phase 2: MVP completion
+
+**Goal:** Complete core product flows with reliable validation and testing.  
+**Estimated effort:** 4-6 weeks.
+
+- Add full trip edit/cancel lifecycle and clear participant rules.
+- Add pagination/filtering to listings.
+- Add email/account confirmation or explicit account policy.
+- Add notification basics for request approval, trip join/leave, trip cancellation.
+- Expand automated tests for all controllers/services/repositories using mocks or test DB.
+- Add user documentation/setup guide.
+- Normalize role model around Identity only.
+
+### Phase 3: Production readiness
+
+**Goal:** Deploy securely and operate reliably.  
+**Estimated effort:** 6-10 weeks.
+
+- Add deployment scripts/IaC or Docker-based deployment.
+- Add staging/production environment separation.
+- Add health checks, monitoring, centralized logs, and audit logs.
+- Add backup/restore runbook and database deployment pipeline.
+- Add security headers, rate limiting, lockout policy, and vulnerability scanning.
+- Load test expected traffic and tune indexes/procedures.
+- Add global exception handling and user-safe errors.
+
+### Phase 4: Scale and growth
+
+**Goal:** Support larger user base, integrations, and multi-client experiences.  
+**Estimated effort:** 3-6 months.
+
+- Introduce application service layer and REST API.
+- Add mobile-ready auth and API versioning.
+- Add caching for reference data and dashboards.
+- Add background jobs for notifications, syncs, reminders, and cleanup.
+- Add real-time notifications with SignalR.
+- Add payment/trip settlement model if monetization requires it.
+- Add analytics/reporting and admin exports.
+
+---
+
+## SECTION 13: Final Scorecard
+
+| Category | Score / 10 |
+|---|---:|
+| Architecture | 6 |
+| Code Quality | 5 |
+| Security | 4 |
+| Database Design | 5 |
+| DevOps | 2 |
+| Scalability | 4 |
+| Maintainability | 5 |
+| Documentation | 3 |
+| Overall Project Health | 5 |
+
+### Overall interpretation
+
+Trip Coordination is a functional MVP-grade project with meaningful business workflows and a reasonable .NET foundation. It is not production-ready yet. The highest-leverage improvements are security cleanup, database versioning, CI/CD, authorization hardening, and moving business workflows out of large MVC controllers into application services.
+
+---
+
+## SECTION 14: Appendix
+
+### Controllers inventory
+
+| Controller | Primary responsibilities |
+|---|---|
+| `AdminController` | Admin dashboard, residences, towns, trips, Back4App town sync. |
+| `DemoLoginController` | Demo role login for Admin/Student/Organizer. |
+| `HomeController` | Landing page, trip listing setup, legacy signup/display pages, privacy/error. |
+| `ProfileController` | View, complete, and edit user profile. |
+| `RouteController` | View, create, edit, delete routes. |
+| `RouteRequestController` | Create/view/delete/approve route requests. |
+| `StudentController` | Student dashboard, chart endpoints, joined trips. |
+| `TripController` | Trip listing, details, joining, creation, deletion, destination removal. |
+| `TripCreatorController` | Organizer dashboard and organizer trip views/chart data. |
+| `TripDestinationTownController` | Trip destination town management. |
+| `TripParticipantController` | View/delete participants for a trip. |
+| `TripRequestController` | Create/view/delete/approve trip requests. |
+| `UserController` | Admin user listing, blocking/unblocking, role editing. |
+
+### Repository inventory
+
+| Repository/interface | Purpose |
+|---|---|
+| `ISqlDataAccess` / `SqlDataAccess` | Shared Dapper stored procedure execution. |
+| `IAdminDashboardRepository` / `AdminDashboardRepository` | Admin stats, charts, recent activity. |
+| `IOrganizerDashboardRepository` / `OrganizerDashboardRepository` | Organizer stats, charts, upcoming trip, requests. |
+| `IStudentDashboardRepository` / `StudentDashboardRepository` | Student stats, charts, upcoming trip, requests. |
+| `IProfileRepository` / `ProfileRepository` | Profile CRUD. |
+| `IResidenceRepository` / `ResidenceRepository` | Residence CRUD. |
+| `IRoleRepository` / `RoleRepository` | Custom role CRUD. |
+| `IRouteRepository` / `RouteRepository` | Route CRUD/soft delete. |
+| `IRouteRequestRepository` / `RouteRequestRepository` | Route request create/list/delete/approve. |
+| `ITownRepository` / `TownRepository` | Town CRUD. |
+| `ITripDestinationTownRepository` / `TripDestinationTownRepository` | Trip destination create/list/update/remove. |
+| `ITripParticipantRepository` / `TripParticipantRepository` | Participant create/list/update/delete/leave. |
+| `ITripRepository` / `TripRepository` | Trip create/search/detail/join/delete/stops/user trips. |
+| `ITripRequestRepository` / `TripRequestRepository` | Trip request create/list/delete/approve. |
+| `IUserRepository` / `UserRepository` | Custom user CRUD, joined trips, user-with-role. |
+| `IUserRoleRepository` / `UserRoleRepository` | Custom user-role CRUD. |
+
+### Models inventory
+
+#### Domain models
+
+- `ApplicationUser`
+- `Back4AppTownDto`
+- `Profile`
+- `Residence`
+- `Role`
+- `RouteRequest`
+- `Town`
+- `Trip`
+- `TripDestinationTown`
+- `TripParticipant`
+- `TripRequest`
+- `TripRoute`
+- `User`
+- `UserRole`
+
+#### UI model
+
+- `ErrorViewModel`
+
+### ViewModel inventory
+
+#### Common ViewModels
+
+- `AdminDashboardViewModel`
+- `ChartDataPoint`
+- `CreateProfileViewModel`
+- `CreateRouteViewModel`
+- `CreateTripViewModel`
+- `MyTripFlatRow`
+- `MyTripGroupedViewModel`
+- `OrganizerDashboardViewModel`
+- `OrganizerTripStatsViewModel`
+- `RecentActivityViewModel`
+- `RouteRequestViewModel`
+- `StudentDashboardViewModel`
+- `StudentTripStatsViewModel`
+- `TripDestinationViewModel`
+- `TripDetailsViewModel`
+- `TripFlatRow`
+- `TripListingViewModel`
+- `TripParticipantViewModel`
+- `TripRequestSummaryViewModel`
+- `TripRequestViewModel`
+- `TripSeatUtilizationChartViewModel`
+- `TripStatsViewModel`
+- `TripStop`
+- `TripTownPriceViewModel`
+- `TripViewModel`
+- `TripWithDestinationsViewModel`
+- `UpcomingTripViewModel`
+- `UserStatsViewModel`
+- `UserWithRoleViewModel`
+
+#### UI ViewModels
+
+- `CreateTripViewModelUI`
+- `TripDetailsViewModelUI`
+- `TripListingViewModelUI`
+- `TripParticipantViewModelUI`
+- `TripViewModelUI`
+
+### Stored procedure inventory
+
+- `sp_Add_RouteRequest`
+- `sp_Add_TripRequest`
+- `sp_AddTripStop`
+- `sp_Admin_GetRecentActivity`
+- `sp_Admin_GetTripOverview`
+- `sp_Admin_GetTripsCreatedByMonth`
+- `sp_Admin_GetUserSummary`
+- `sp_Approve_RouteRequest`
+- `sp_Approve_TripRequest`
+- `sp_Create_Profile`
+- `sp_Create_Residence`
+- `sp_Create_Role`
+- `sp_Create_Route`
+- `sp_Create_Town`
+- `sp_Create_Trip`
+- `sp_Create_TripDestinationTown`
+- `sp_Create_TripParticipant`
+- `sp_Create_User`
+- `sp_Create_UserRole`
+- `sp_Delete_Profile`
+- `sp_Delete_Residence`
+- `sp_Delete_Role`
+- `sp_Delete_Route`
+- `sp_Delete_RouteRequest`
+- `sp_Delete_Town`
+- `sp_Delete_Trip`
+- `sp_Delete_TripParticipant`
+- `sp_Delete_TripRequest`
+- `sp_Delete_User`
+- `sp_Delete_UserRole`
+- `sp_Find_TripDetails`
+- `sp_Find_Trips`
+- `sp_Find_Trips_With_Destinations`
+- `sp_Get_All_RouteRequests`
+- `sp_Get_All_Routes`
+- `sp_Get_All_TripRequests`
+- `sp_Get_All_User_RouteRequest`
+- `sp_Get_All_User_Trips`
+- `sp_Get_All_User_TripRequests`
+- `sp_Get_Profile`
+- `sp_Get_Profiles`
+- `sp_Get_Residence`
+- `sp_Get_Residences`
+- `sp_Get_Role`
+- `sp_Get_Roles`
+- `sp_Get_Route_ByID`
+- `sp_Get_RouteRequest_By_Id`
+- `sp_Get_Town`
+- `sp_Get_Towns`
+- `sp_Get_Trip`
+- `sp_Get_TripDestinationTown`
+- `sp_Get_TripDestinationTwons`
+- `sp_Get_TripParticipant`
+- `sp_Get_TripParticipantS`
+- `sp_Get_TripParticipants_By_TripID`
+- `sp_Get_TripRequest_ByID`
+- `sp_Get_User`
+- `sp_Get_User_Profile`
+- `sp_Get_User_with_Role`
+- `sp_Get_UserRole`
+- `sp_Get_UserRoles`
+- `sp_Get_Users`
+- `sp_Get_JoinedTrips_By_User`
+- `sp_GetAll_Trips`
+- `sp_GetNextUpcomingTrip`
+- `sp_GetOganizerStats`
+- `sp_GetOrganizerUpcomingTrip`
+- `sp_GetRecentTripRequests`
+- `sp_GetStudentTripStats`
+- `sp_GetUserRoleDistribution`
+- `sp_GetUsersRecentTripRequests`
+- `sp_Join_Trip`
+- `sp_Leave_Trip`
+- `sp_Organizer_GetMonthlyTripCount`
+- `sp_Organizer_GetSeatUtilizationByTrip`
+- `sp_Remove_TripDestination`
+- `sp_Remove_TripParticipant`
+- `sp_SoftDelete_Trip`
+- `sp_Student_GetTripRequestatusDestripution`
+- `sp_Student_GetTripsJoinedByMonth`
+- `sp_Update_Profile`
+- `sp_Update_Residence`
+- `sp_Update_Role`
+- `sp_Update_Route`
+- `sp_Update_Town`
+- `sp_Update_Trip`
+- `sp_Update_TripDestinationTown`
+- `sp_Update_TripParticipant`
+- `sp_Update_User`
+- `sp_Update_UserRole`
+
+### External packages
+
+#### `TripCoordination.UI`
+
+- `Microsoft.AspNetCore.Identity.EntityFrameworkCore` 8.0.12
+- `Microsoft.AspNetCore.Identity.UI` 8.0.11
+- `Microsoft.Data.SqlClient` 6.0.1
+- `Microsoft.EntityFrameworkCore.Sqlite` 8.0.11
+- `Microsoft.EntityFrameworkCore.SqlServer` 9.0.1
+- `Microsoft.EntityFrameworkCore.Tools` 9.0.1
+- `Microsoft.VisualStudio.Web.CodeGeneration.Design` 8.0.7
+
+#### `TripCoordination.Data`
+
+- `Dapper` 2.1.44
+- `Microsoft.AspNetCore.Identity.EntityFrameworkCore` 8.0.12
+- `Microsoft.AspNetCore.Identity.UI` 8.0.11
+- `Microsoft.Data.SqlClient` 6.0.1
+- `Microsoft.EntityFrameworkCore.SqlServer` 9.0.1
+- `Microsoft.EntityFrameworkCore.Tools` 9.0.1
+- `Microsoft.Extensions.Configuration.Abstractions` 9.0.1
+
+#### `TripCoordination.Common`
+
+- `Microsoft.AspNet.Mvc` 5.3.0
+- `Microsoft.AspNetCore.Mvc.Core` 2.3.0
+- `Microsoft.AspNetCore.Mvc.TagHelpers` 2.3.0
+
+#### `TripCoordination.Tests`
+
+- `FluentAssertions` 8.5.0
+- `Microsoft.NET.Test.Sdk` 17.14.1
+- `moq` 4.20.72
+- `xunit` 2.9.3
+- `xunit.runner.visualstudio` 3.1.3
+
+### Configuration files
+
+| File | Purpose / notes |
+|---|---|
+| `TripCoordination.sln` | Visual Studio solution. |
+| `TripCoordination.UI/appsettings.json` | Main app configuration; contains logging, connection strings, Back4App placeholders, and hardcoded credentials. |
+| `TripCoordination.UI/appsettings.Development.json` | Development configuration. |
+| `TripCoordination.UI/Properties/launchSettings.json` | Local launch profiles. |
+| `TripCoordination.UI/TripCoordination.UI.csproj` | Web app project, target framework, packages, project references, UserSecretsId. |
+| `TripCoordination.Data/TripCoordination.Data.csproj` | Data project packages and Common reference. |
+| `TripCoordination.Common/TripCoordination.Common.csproj` | Common project packages. |
+| `TripCoordination.Tests/TripCoordination.Tests.csproj` | Test project packages and references. |
+| `ClassLibrary1/ClassLibrary1.csproj` | Placeholder library project. |
+
+### Audit commands used
+
+Representative commands used for this report:
+
+```bash
+find .. -name AGENTS.md -print
+rg --files -g '!bin' -g '!obj'
+find . -maxdepth 3 -name '*.csproj' -print
+rg --files TripCoordination.UI/Controllers
+rg -n "StoredProcedure|CommandType|ExecuteAsync|QueryAsync|sp_" TripCoordination.Data/Repository TripCoordination.Data/DataAccess TripCoordination.UI/Controllers
+python3 - <<'PY'
+from pathlib import Path
+import re
+for p in sorted(Path('TripCoordination.Data/Repository').glob('*.cs')):
+    txt=p.read_text(errors='ignore')
+    procs=sorted(set(re.findall(r'"(sp_[^"]+)"', txt)))
+    if procs:
+        print(p.name, procs)
+PY
+find TripCoordination.UI/Views -maxdepth 2 -type f -name '*.cshtml' | sort
+find . -maxdepth 3 \( -name '*.yml' -o -name '*.yaml' -o -name 'Dockerfile' -o -name 'docker-compose*' -o -name '*.json' -o -name '*.config' \) -print | sort
+```


### PR DESCRIPTION
### Motivation

- Produce a complete technical audit of the Trip Coordination codebase so engineers, architects, security, and DevOps can understand current state, risks, and priorities.

### Description

- Add `docs/PROJECT_TECHNICAL_AUDIT.md`, a 14‑section audit covering executive summary, repository structure, feature inventory, architecture review, database assessment, code quality, security assessment, DevOps readiness, performance/scalability, recruiter/architect assessments, roadmap, scorecard, and an appendix with controllers/repositories/models/ViewModels/stored-procedure and package inventories.

### Testing

- Verified the report file exists with `test -s docs/PROJECT_TECHNICAL_AUDIT.md` and ran a Python check that confirmed all 14 `## SECTION` headings and the required "Not found in repository." phrase were present.  
- Attempted to run `dotnet test TripCoordination.sln` but the `dotnet` CLI was not available in the environment so unit tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c2a7d92bc832fa93167db3b6e01ce)